### PR TITLE
[BUGFIX] Yield ideaMaker GCode commands

### DIFF
--- a/preprocess_cancellation/slicers/ideamaker.py
+++ b/preprocess_cancellation/slicers/ideamaker.py
@@ -69,6 +69,8 @@ def preprocess_ideamaker_to_klipper(
             break
 
     for line in infile:
+        yield line
+
         if line.startswith(";PRINTING_ID:"):
             printing_id = line.split(":")[1].strip()
             if current_object:

--- a/tests/test_preprocessor.py
+++ b/tests/test_preprocessor.py
@@ -67,6 +67,8 @@ def test_m486():
     assert "EXCLUDE_OBJECT_DEFINE NAME=2" in definitions
     assert "EXCLUDE_OBJECT_DEFINE NAME=3" in definitions
 
+    assert "G1 X137.005 Y163.371 E0.29649" in results
+
     assert results.count("EXCLUDE_OBJECT_START NAME=0") == 25
     assert results.count("EXCLUDE_OBJECT_END NAME=0") == 25
 
@@ -99,6 +101,19 @@ def test_superslicer():
     assert "EXCLUDE_OBJECT_DEFINE NAME=union_3_id_2_copy_0" in definitions
     assert "EXCLUDE_OBJECT_DEFINE NAME=cylinder_2_id_1_copy_0" in definitions
 
+    assert "G1 X164.398 Y143.144 E0.05245" in results
+
+    assert results.count("EXCLUDE_OBJECT_START NAME=cube_1_id_0_copy_0") == 25
+    assert results.count("EXCLUDE_OBJECT_END NAME=cube_1_id_0_copy_0") == 25
+
+    assert results.count("EXCLUDE_OBJECT_START NAME=cube_1_id_0_copy_1") == 25
+    assert results.count("EXCLUDE_OBJECT_END NAME=cube_1_id_0_copy_1") == 25
+
+    assert results.count("EXCLUDE_OBJECT_START NAME=union_3_id_2_copy_0") == 25
+    assert results.count("EXCLUDE_OBJECT_END NAME=union_3_id_2_copy_0") == 25
+
+    assert results.count("EXCLUDE_OBJECT_START NAME=cylinder_2_id_1_copy_0") == 25
+    assert results.count("EXCLUDE_OBJECT_END NAME=cylinder_2_id_1_copy_0") == 25
 
 def test_prusaslicer():
     with (gcode_path / "prusaslicer.gcode").open("r") as f:
@@ -118,6 +133,8 @@ def test_prusaslicer():
     assert "EXCLUDE_OBJECT_DEFINE NAME=cube_1_id_0_copy_0" in definitions
     assert "EXCLUDE_OBJECT_DEFINE NAME=cube_1_id_0_copy_1" in definitions
     assert "EXCLUDE_OBJECT_DEFINE NAME=union_3_id_2_copy_0" in definitions
+
+    assert "G1 X135.298 Y137.411 E0.03649" in results
 
     assert results.count("EXCLUDE_OBJECT_START NAME=cylinder_2_id_1_copy_0") == 25
     assert results.count("EXCLUDE_OBJECT_END NAME=cylinder_2_id_1_copy_0") == 25
@@ -151,6 +168,8 @@ def test_slic3r():
     assert "EXCLUDE_OBJECT_DEFINE NAME=cylinder_2_stl_id_1_copy_0" in definitions
     assert "EXCLUDE_OBJECT_DEFINE NAME=union_3_stl_id_2_copy_0" in definitions
 
+    assert "G1 X97.912 Y94.709 E3.82225" in results
+
     assert results.count("EXCLUDE_OBJECT_START NAME=cube_1_stl_id_0_copy_0") == 16
     assert results.count("EXCLUDE_OBJECT_END NAME=cube_1_stl_id_0_copy_0") == 16
 
@@ -183,6 +202,8 @@ def test_cura():
     assert "EXCLUDE_OBJECT_DEFINE NAME=union_3_stl" in definitions
     assert "EXCLUDE_OBJECT_DEFINE NAME=cube_1_stl_1" in definitions
 
+    assert "G1 X152.563 Y136.21 E0.02148" in results
+
     assert results.count("EXCLUDE_OBJECT_START NAME=cylinder_2_stl") == 25
     assert results.count("EXCLUDE_OBJECT_END NAME=cylinder_2_stl") == 25
 
@@ -214,6 +235,8 @@ def test_ideamaker():
     assert "EXCLUDE_OBJECT_DEFINE NAME=test_bed_part2_3mf" in definitions
     assert "EXCLUDE_OBJECT_DEFINE NAME=test_bed_part0_3mf" in definitions
     assert "EXCLUDE_OBJECT_DEFINE NAME=test_bed_part0_1_3mf" in definitions
+
+    assert "G1 X100.759 Y106.827 E11.9581" in results
 
     assert results.count("EXCLUDE_OBJECT_START NAME=test_bed_part1_3mf") == 32
     assert results.count("EXCLUDE_OBJECT_END NAME=test_bed_part1_3mf") == 32

--- a/tests/test_preprocessor_with_shapely.py
+++ b/tests/test_preprocessor_with_shapely.py
@@ -74,6 +74,8 @@ def test_m486():
     assert "EXCLUDE_OBJECT_DEFINE NAME=2 " in output
     assert "EXCLUDE_OBJECT_DEFINE NAME=3 " in output
 
+    assert "G1 X137.005 Y163.371 E0.29649" in results
+
     assert results.count("EXCLUDE_OBJECT_START NAME=0") == 25
     assert results.count("EXCLUDE_OBJECT_END NAME=0") == 25
 
@@ -98,11 +100,26 @@ def test_superslicer():
                 )
             )
         )
+        results = output.split("\n")
 
     assert "EXCLUDE_OBJECT_DEFINE NAME=cube_1_id_0_copy_0" in output
     assert "EXCLUDE_OBJECT_DEFINE NAME=cube_1_id_0_copy_1" in output
     assert "EXCLUDE_OBJECT_DEFINE NAME=union_3_id_2_copy_0" in output
     assert "EXCLUDE_OBJECT_DEFINE NAME=cylinder_2_id_1_copy_0" in output
+
+    assert "G1 X164.398 Y143.144 E0.05245" in results
+
+    assert results.count("EXCLUDE_OBJECT_START NAME=cube_1_id_0_copy_0") == 25
+    assert results.count("EXCLUDE_OBJECT_END NAME=cube_1_id_0_copy_0") == 25
+
+    assert results.count("EXCLUDE_OBJECT_START NAME=cube_1_id_0_copy_1") == 25
+    assert results.count("EXCLUDE_OBJECT_END NAME=cube_1_id_0_copy_1") == 25
+
+    assert results.count("EXCLUDE_OBJECT_START NAME=union_3_id_2_copy_0") == 25
+    assert results.count("EXCLUDE_OBJECT_END NAME=union_3_id_2_copy_0") == 25
+
+    assert results.count("EXCLUDE_OBJECT_START NAME=cylinder_2_id_1_copy_0") == 25
+    assert results.count("EXCLUDE_OBJECT_END NAME=cylinder_2_id_1_copy_0") == 25
 
 
 def test_prusaslicer():
@@ -122,6 +139,8 @@ def test_prusaslicer():
     assert "EXCLUDE_OBJECT_DEFINE NAME=cube_1_id_0_copy_0 " in output
     assert "EXCLUDE_OBJECT_DEFINE NAME=cube_1_id_0_copy_1 " in output
     assert "EXCLUDE_OBJECT_DEFINE NAME=union_3_id_2_copy_0 " in output
+
+    assert "G1 X135.298 Y137.411 E0.03649" in results
 
     assert results.count("EXCLUDE_OBJECT_START NAME=cylinder_2_id_1_copy_0") == 25
     assert results.count("EXCLUDE_OBJECT_END NAME=cylinder_2_id_1_copy_0") == 25
@@ -154,6 +173,8 @@ def test_slic3r():
     assert "EXCLUDE_OBJECT_DEFINE NAME=cylinder_2_stl_id_1_copy_0" in output
     assert "EXCLUDE_OBJECT_DEFINE NAME=union_3_stl_id_2_copy_0" in output
 
+    assert "G1 X97.912 Y94.709 E3.82225" in results
+
     assert results.count("EXCLUDE_OBJECT_START NAME=cube_1_stl_id_0_copy_0") == 16
     assert results.count("EXCLUDE_OBJECT_END NAME=cube_1_stl_id_0_copy_0") == 16
 
@@ -185,6 +206,8 @@ def test_cura():
     assert "EXCLUDE_OBJECT_DEFINE NAME=union_3_stl" in output
     assert "EXCLUDE_OBJECT_DEFINE NAME=cube_1_stl_1" in output
 
+    assert "G1 X152.563 Y136.21 E0.02148" in results
+
     assert results.count("EXCLUDE_OBJECT_START NAME=cylinder_2_stl") == 25
     assert results.count("EXCLUDE_OBJECT_END NAME=cylinder_2_stl") == 25
 
@@ -215,6 +238,8 @@ def test_ideamaker():
     assert "EXCLUDE_OBJECT_DEFINE NAME=test_bed_part2_3m" in output
     assert "EXCLUDE_OBJECT_DEFINE NAME=test_bed_part0_3m" in output
     assert "EXCLUDE_OBJECT_DEFINE NAME=test_bed_part0_1_3m" in output
+
+    assert "G1 X100.759 Y106.827 E11.9581" in results
 
     assert results.count("EXCLUDE_OBJECT_START NAME=test_bed_part1_3mf") == 32
     assert results.count("EXCLUDE_OBJECT_END NAME=test_bed_part1_3mf") == 32


### PR DESCRIPTION
Normal GCode command were not being exported for the ideaMaker slicer.

Add missing yield statement and update all tests to check that at least one expected gcode move command is in the output file.